### PR TITLE
support for any iterable object + keys are sorted

### DIFF
--- a/prettyprint/prettyprint.py
+++ b/prettyprint/prettyprint.py
@@ -8,17 +8,30 @@ except ImportError:
 
 __all__ = ['pp', 'pp_str']
 
+class MyEncoder (json.JSONEncoder):
+    def default(self, o):
+        try:
+            iterable = iter(o)
+        except TypeError:
+            pass
+        else:
+            return list(iterable)
+        
+        try:
+            return json.JSONEncoder.default(self, o)
+        except TypeError:
+            return str(o)
+
 def pp(obj):
   print pp_str(obj)
 
 def pp_str(obj):
-  if isinstance(obj, set):
-    obj = list(obj)
-  if isinstance(obj, list) or isinstance(obj, dict) or isinstance(obj, tuple):
-    orig = json.dumps(obj, indent=4)
-    return eval("u'''%s'''" % orig).encode('utf-8')
-  else:
-    return obj
+  orig = json.dumps(obj, 
+               indent=4, 
+               sort_keys=True, 
+               skipkeys=True, 
+               cls=MyEncoder)
+  return eval("u'''%s'''" % orig).encode('utf-8')
 
 if __name__ == '__main__':
   target = ['want pretty printing', '望麗出力']

--- a/test/prettyprint_test.py
+++ b/test/prettyprint_test.py
@@ -29,8 +29,52 @@ class PrettyPrintTest(unittest.TestCase):
 
   def testSet(self):
     set1 = set(['John', 'Jane', 'Jack', 'Janice'])
-    print pp_str(set1)
-    self.assertTrue(True)
+    pp(set1)
+    expected='''
+[
+    "Jane", 
+    "Janice", 
+    "John", 
+    "Jack"
+]
+'''.strip()
+    self.assertEqual(pp_str(set1), expected)
+
+  def testNestedSet(self):
+    set1 = list([6, set([2,1,3]), 5,[3,1,2], None])
+    pp(set1)
+    expected='''
+[
+    6, 
+    [
+        1, 
+        2, 
+        3
+    ], 
+    5, 
+    [
+        3, 
+        1, 
+        2
+    ], 
+    null
+]
+'''.strip()
+    self.assertEqual(pp_str(set1), expected)
+
+  def testObject(self):
+    class MyClass(object):
+      def __str__(self):
+          return "<MyClass>"
+    ls = list([1, MyClass()])
+    pp(ls)
+    expected='''
+[
+    1, 
+    "<MyClass>"
+]
+'''.strip()
+    self.assertEqual(pp_str(ls), expected)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This fork can prettyprint any nested iterable object including sets.
For examples check unit tests.
Additionally it sorts sets, so output is always the same.

Also solution for #2
